### PR TITLE
Implement `is_human_readable` to return `false`

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -42,7 +42,12 @@ struct Deserializer<'a> {
 }
 impl<'a, 'r> serde::de::Deserializer<'a> for &'r mut Deserializer<'a> {
     type Error = SerdeAsn1DerError;
-    
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     fn deserialize_any<V: Visitor<'a>>(self, visitor: V) -> Result<V::Value> {
         match self.object.tag() {
             Boolean::TAG => self.deserialize_bool(visitor),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -145,7 +145,12 @@ impl<'a, 'r, S: Sink> serde::ser::Serializer for &'r mut Serializer<'a, S> {
     type SerializeMap = KeyValueWriter;
     type SerializeStruct = SequenceWriter<'a, 'r, S>;
     type SerializeStructVariant = KeyValueWriter;
-    
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
         Ok(v.encode(&mut self.sink).propagate(e!("Failed to write boolean"))?)
     }


### PR DESCRIPTION
Currently, [is_human_readable](https://docs.rs/serde/latest/serde/trait.Serializer.html#method.is_human_readable) is not manually implemented and thus returns `true` (default). As a consequence, types supporting a more compact binary representation are serialized inefficiently (typically into a string representation).

This is a breaking change: previously serialized types supporting a compact representation will fail at deserialization with this commit.

This is [an issue](https://github.com/Devolutions/picky-rs/issues/201#issuecomment-1454544968) preventing adoption [by some projects](https://github.com/nucypher/rust-umbral/pull/111#issue-1533580324).